### PR TITLE
Allow Papers to be mined via ENV var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
           START_PAGE: 1
           END_PAGE: 2
           PAGE_SIZE: 10
+          TYPES_TO_MINE: "FieldOfStudy"
       - image: wurstmeister/zookeeper:latest
       - image: wurstmeister/kafka:latest
         environment:

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -1,4 +1,6 @@
+import * as Context from './context';
 declare const START_PAGE: number;
 declare const END_PAGE: number;
 declare const PAGE_SIZE: number;
-export { NAME, KAFKA_ADDRESS, OUTPUT_TOPIC, START_PAGE, END_PAGE, PAGE_SIZE, MAG_EVALUATE_URL, MAG_API_KEY };
+declare const TYPES_TO_MINE: Array<Context.Types>;
+export { NAME, KAFKA_ADDRESS, OUTPUT_TOPIC, START_PAGE, END_PAGE, PAGE_SIZE, TYPES_TO_MINE, MAG_EVALUATE_URL, MAG_API_KEY };

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,3 +13,5 @@ const END_PAGE = parseInt(process.env.END_PAGE) || Infinity;
 exports.END_PAGE = END_PAGE;
 const PAGE_SIZE = parseInt(process.env.PAGE_SIZE) || 100;
 exports.PAGE_SIZE = PAGE_SIZE;
+const TYPES_TO_MINE = process.env.TYPES_TO_MINE ? process.env.TYPES_TO_MINE.split(',') : ['FieldOfStudy'];
+exports.TYPES_TO_MINE = TYPES_TO_MINE;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,5 +1,6 @@
 import { Subscription } from '@reactivex/rxjs';
 export declare type MinerConfig = {
     name: string;
+    types?: Array<'FieldOfStudy' | 'Paper'>;
 };
-export default function init({name}: MinerConfig): Promise<Subscription>;
+export default function init({name, types}: MinerConfig): Promise<Subscription>;

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,17 +8,18 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+const rxjs_1 = require("@reactivex/rxjs");
 const feedbackfruits_knowledge_engine_1 = require("feedbackfruits-knowledge-engine");
 const miner_1 = require("./miner");
 const Config = require("./config");
-function init({ name }) {
+function init({ name, types = Config.TYPES_TO_MINE }) {
     return __awaiter(this, void 0, void 0, function* () {
         console.log('Starting MAG miner');
         const send = yield feedbackfruits_knowledge_engine_1.Miner({ name, customConfig: Config });
-        return miner_1.mine('FieldOfStudy')
+        return rxjs_1.Observable.merge(...types.map(type => miner_1.mine(type)))
             .map(doc => ({ action: 'write', key: doc['@id'], data: doc }))
             .subscribe({
-            next: send,
+            next: value => send(value),
             error: (err) => { console.error(err); throw err; },
             complete: () => {
                 console.log('Done mining.');

--- a/lib/types/paper.js
+++ b/lib/types/paper.js
@@ -8,11 +8,12 @@ function paperToQuad(entity) {
     let { Id: id, Ti: title, E: metadataStr, AA: authors, 'F': entities } = entity;
     console.log('Parsing metadata.');
     let metadata = JSON.parse(metadataStr);
-    let { DN: displayName, D: description, } = metadata;
+    let { DN: displayName, D: description, DOI } = metadata;
     let subject = `<http://academic.microsoft.com/#/detail/${id}>`;
     let quads = [
         { subject, predicate: Context.name, object: displayName },
         description && { subject, predicate: Context.description, object: description },
+        { subject, predicate: Context.sameAs, object: `<https://dx.doi.org/${DOI}>` },
         { subject, predicate: Context.type, object: Context.Knowledge.Resource },
         { subject, predicate: Context.type, object: Context.DigitalDocument },
         { subject, predicate: Context.type, object: Context.ScholarlyArticle },

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 require('dotenv').load({ silent: true });
+import * as Context from './context';
 
 const {
   NAME = 'microsoft-academic-graph',
@@ -13,6 +14,8 @@ const START_PAGE = parseInt(process.env.START_PAGE) || 1;
 const END_PAGE = parseInt(process.env.END_PAGE) || Infinity;
 const PAGE_SIZE = parseInt(process.env.PAGE_SIZE) || 100;
 
+const TYPES_TO_MINE: Array<Context.Types> = process.env.TYPES_TO_MINE ? process.env.TYPES_TO_MINE.split(',') as Array<Context.Types> : [ 'FieldOfStudy' ];
+
 export {
   NAME,
   KAFKA_ADDRESS,
@@ -21,6 +24,7 @@ export {
   START_PAGE,
   END_PAGE,
   PAGE_SIZE,
+  TYPES_TO_MINE,
 
   MAG_EVALUATE_URL,
   MAG_API_KEY,

--- a/src/types/paper.ts
+++ b/src/types/paper.ts
@@ -21,12 +21,15 @@ export function paperToQuad(entity): Quad[] {
   let {
     DN: displayName,
     D: description,
+    DOI
   } = metadata;
 
   let subject = `<http://academic.microsoft.com/#/detail/${id}>`;
   let quads = [
     { subject, predicate: Context.name, object: displayName },
     description && { subject, predicate: Context.description, object: description },
+
+    { subject, predicate: Context.sameAs, object: `<https://dx.doi.org/${DOI}>`},
 
     { subject, predicate: Context.type, object: Context.Knowledge.Resource },
     { subject, predicate: Context.type, object: Context.DigitalDocument },

--- a/test/miner.js
+++ b/test/miner.js
@@ -58,7 +58,20 @@ test('it mines fields of study', t => {
       error: (...args) => reject(...args),
       complete: (...args) => reject(...args),
     });
-  }).then((...args) => t.pass(...args), (...args) => t.fail(...args));
+  }).then((operation) => {
+    return t.deepEqual(operation, {
+      '@id': 'http://academic.microsoft.com/#/detail/75678561',
+      'http://schema.org/name': [
+        '0-10 V lighting control',
+      ],
+      'http://schema.org/sameAs': [
+        '<http://dbpedia.org/resource/0-10_V_lighting_control>',
+      ],
+      'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [
+        '<http://academic.microsoft.com/FieldOfStudy>',
+      ]
+    });
+  }, (...args) => t.fail(...args));
 });
 
 test('it mines papers', t => {
@@ -74,5 +87,31 @@ test('it mines papers', t => {
       error: (...args) => reject(...args),
       complete: (...args) => reject(...args),
     });
-  }).then((...args) => t.pass(...args), (...args) => t.fail(...args));
+  }).then((operation) => {
+    return t.deepEqual(operation, {
+      '@id': 'http://academic.microsoft.com/#/detail/1994667404',
+      'http://schema.org/about': [
+        '<http://dbpedia.org/resource/High_electron_mobility_transistor>',
+        '<http://dbpedia.org/resource/Chemistry>',
+        '<http://dbpedia.org/resource/Physics>',
+      ],
+      'http://schema.org/author': [
+        '<http://academic.microsoft.com/#/detail/1818411831>',
+        '<http://academic.microsoft.com/#/detail/2054892899>',
+        '<http://academic.microsoft.com/#/detail/2109856768>',
+        '<http://academic.microsoft.com/#/detail/1982950984>',
+      ],
+      'http://schema.org/name': [
+        '0.05-Î¼m-Gate InAlAs/InGaAs High Electron Mobility Transistor and Reduction of Its Short-Channel Effects',
+      ],
+      'http://schema.org/sameAs': [
+        '<https://dx.doi.org/10.1143/JJAP.33.798>',
+      ],
+      'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': [
+        '<https://knowledge.express/Resource>',
+        '<http://schema.org/DigitalDocument>',
+        '<http://schema.org/ScholarlyArticle>',
+      ],
+    });
+  }, (...args) => t.fail(...args));
 });


### PR DESCRIPTION
This PR allows the mined types to be configured via the ENV var `TYPES_TO_MINE`. It also makes the test for the miner more appropriate.